### PR TITLE
Adds github.com/beego/social-auth to example/main.go

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/context"
 	"github.com/astaxie/beego/orm"
+	"github.com/beego/social-auth"
 	"github.com/beego/social-auth/apps"
 )
 


### PR DESCRIPTION
Example app won't compile, because there is a missing import. This pull request fixes that
